### PR TITLE
Handle failing requests for Rails 3

### DIFF
--- a/lib/relevance/tarantula/rails_integration_proxy.rb
+++ b/lib/relevance/tarantula/rails_integration_proxy.rb
@@ -33,10 +33,12 @@ module Relevance
 
       [:get, :post, :put, :delete].each do |verb|
         define_method(verb) do |url, *args|
-          response = integration_test.response
+          response = nil
           begin
             integration_test.send(verb, url, *args)
+            response = integration_test.response
           rescue Exception => e
+            response = integration_test.response
             alter_response(response, '500', e.message + "\n\n" + e.backtrace.join("\n"))
           end
           patch_response(url, response)

--- a/lib/relevance/tarantula/rails_integration_proxy.rb
+++ b/lib/relevance/tarantula/rails_integration_proxy.rb
@@ -37,7 +37,8 @@ module Relevance
           begin
             integration_test.send(verb, url, *args)
             response = integration_test.response
-          rescue ActiveRecord::RecordNotFound => e
+          rescue ActiveRecord::RecordNotFound, 
+                 ActionController::RoutingError => e
             response = integration_test.response
             alter_response(response, '404', e.message + "\n\n" + e.backtrace.join("\n"))
           rescue Exception => e

--- a/lib/relevance/tarantula/rails_integration_proxy.rb
+++ b/lib/relevance/tarantula/rails_integration_proxy.rb
@@ -37,6 +37,9 @@ module Relevance
           begin
             integration_test.send(verb, url, *args)
             response = integration_test.response
+          rescue ActiveRecord::RecordNotFound => e
+            response = integration_test.response
+            alter_response(response, '404', e.message + "\n\n" + e.backtrace.join("\n"))
           rescue Exception => e
             response = integration_test.response
             alter_response(response, '500', e.message + "\n\n" + e.backtrace.join("\n"))

--- a/spec/relevance/tarantula/rails_integration_proxy_spec.rb
+++ b/spec/relevance/tarantula/rails_integration_proxy_spec.rb
@@ -43,7 +43,19 @@ describe "Relevance::Tarantula::RailsIntegrationProxy" do
     Relevance::Tarantula::RailsIntegrationProxy.new(o)
     o.methods(false).map(&:to_s).sort.should == %w{response response=}
   end
+end
 
+describe "Relevance::Tarantula::RailsIntegrationProxy errors" do
+  it "alters response to contain the error message" do
+    @rip = Relevance::Tarantula::RailsIntegrationProxy.new(stub)
+    @response = Struct.new(:body, :code).new(nil, nil)
+    @rip.integration_test = stub_everything(:response => @response) do |stub|
+      stub.stubs(:get).raises(Exception, 'Internal Server Error')
+    end
+    response = @rip.get("/url")
+    response.code.should == '500'
+    response.body.should =~ /\AInternal Server Error\n\n/
+  end
 end
 
 describe "Relevance::Tarantula::RailsIntegrationProxy patching" do


### PR DESCRIPTION
When a request in a Rails 3 integration test produces an exception, this exception is directly passed to the test, causing it to fail. With Tarantula, exceptions in requests should produce regular responses with a status code of 500, so the crawling can go on. Finally, the test report will show the failed requests.

This branch rescues exceptions and wraps them into the response.
